### PR TITLE
fix: production build due to component style sizes

### DIFF
--- a/ng-christmas-calendar/angular.json
+++ b/ng-christmas-calendar/angular.json
@@ -44,8 +44,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "10kb",
+                  "maximumError": "28kb"
                 }
               ],
               "outputHashing": "all"


### PR DESCRIPTION
After migration from CSS repository to Angular app, revealed contents were implemented as components. Some the examples has a really massive styles, cause all of those beautiful animations are done purely with CSS and HTML.

In that case I'd propose to simply increase budget in angular.json.