### PR TITLE
feat: 🎸 store user visited days in local storage

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,9 +1,11 @@
 import type { ApplicationConfig } from '@angular/core';
 import { provideExperimentalZonelessChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
-
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
-import { routes } from './app.routes';
+import {afterNextRender, inject, provideAppInitializer} from '@angular/core';
+import {provideRouter} from '@angular/router';
+
+import {routes} from './app.routes';
+import { CardStorageService } from './feature/calendar/services/card-storage.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -12,5 +14,12 @@ export const appConfig: ApplicationConfig = {
     provideClientHydration(withEventReplay()),
     // Note: It could be useful to define which card should have reveal ability.
     // {provide: OVERRIDE_CARD_INDEX_TO_REVEAL, useValue: 2},
+    provideAppInitializer(() => {
+      const cardStorageService = inject(CardStorageService);
+
+      afterNextRender(() => {
+        cardStorageService.init();
+      });
+    })
   ],
 };

--- a/src/app/feature/calendar/calendar-grid.component.html
+++ b/src/app/feature/calendar/calendar-grid.component.html
@@ -3,13 +3,13 @@
   <h1>Christmas Calendar</h1>
 </div>
 
-@for (card of cards; track $index) {
+@for (card of cards(); track $index) {
   <div
     class="card day-{{ card.day }}"
     xmasOpenDetailsDialog
     [card]="card"
     [xmasShakeWhenDisabled]="!card.canReveal && !card.revealed"
-    [class.pulse]="card.canReveal && !card.revealed"
+    [class.pulse]="card.canAnimate"
   >
     <label>
       <input type="checkbox" [checked]="card.revealed" [disabled]="!card.canReveal" (change)="card.revealed = !card.revealed" />

--- a/src/app/feature/calendar/directives/open-details-dialog.directive.ts
+++ b/src/app/feature/calendar/directives/open-details-dialog.directive.ts
@@ -2,6 +2,7 @@ import { Dialog } from '@angular/cdk/dialog';
 import { Directive, inject, input } from '@angular/core';
 import { CardDetailsDialogComponent } from '../dialogs/card-details-dialog/card-details-dialog.component';
 import type { UiCalendarCard } from '../interfaces/christmas-calendar-data';
+import { CardStorageService } from '../services/card-storage.service';
 
 @Directive({
   selector: '[xmasOpenDetailsDialog]',
@@ -11,6 +12,7 @@ import type { UiCalendarCard } from '../interfaces/christmas-calendar-data';
 })
 export class OpenDetailsDialogDirective {
   private readonly dialog = inject(Dialog);
+  private readonly cardStorageService = inject(CardStorageService);
 
   readonly card = input.required<UiCalendarCard>();
 
@@ -32,8 +34,14 @@ export class OpenDetailsDialogDirective {
   }
 
   private openDialog(): void {
+    this.storeAsVisited(this.card().day);
+
     this.dialog.open<UiCalendarCard>(CardDetailsDialogComponent, {
       data: this.card(),
     });
+  }
+
+  private storeAsVisited(day: number): void {
+    this.cardStorageService.storeAsVisited(day);
   }
 }

--- a/src/app/feature/calendar/interfaces/christmas-calendar-data.ts
+++ b/src/app/feature/calendar/interfaces/christmas-calendar-data.ts
@@ -29,4 +29,5 @@ export interface CalendarCard {
 export interface UiCalendarCard extends CalendarCard {
   revealed: boolean;
   canReveal: boolean;
+  canAnimate: boolean;
 }

--- a/src/app/feature/calendar/providers/date-range.ts
+++ b/src/app/feature/calendar/providers/date-range.ts
@@ -1,3 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export const OVERRIDE_CARD_INDEX_TO_REVEAL = new InjectionToken<number>('OVERRIDE_CARD_INDEX_TO_REVEAL');

--- a/src/app/feature/calendar/services/calendar.service.ts
+++ b/src/app/feature/calendar/services/calendar.service.ts
@@ -1,34 +1,44 @@
-import { Injectable, inject } from '@angular/core';
 import type { UiCalendarCard } from '../interfaces/christmas-calendar-data';
-import { OVERRIDE_CARD_INDEX_TO_REVEAL } from '../providers/date-range';
 import calendarData from './../../../../../public/content/angular-calendar.json';
+import {Injectable, Signal, computed, inject} from '@angular/core';
+import {CardStorageService} from './card-storage.service';
+
+function processDays(visitedDays: number[], dayOfCardToReveal: number): UiCalendarCard[] {
+  return calendarData.data.map((card) => {
+    const hasContents = card.contents.length > 0;
+
+    const canReveal = hasContents;
+    const revealed = canReveal && visitedDays.includes(card.day);
+    const canAnimate = dayOfCardToReveal == card.day && !revealed;
+
+    return {
+      ...card,
+      revealed,
+      canReveal,
+      canAnimate,
+    };
+  });
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class CalendarService {
-  private readonly overrideCardIndexToReveal = inject(OVERRIDE_CARD_INDEX_TO_REVEAL, {
-    optional: true,
+  private readonly cardStorageService = inject(CardStorageService);
+  private readonly dayOfCardToReveal = this.getLastContentDay();
+
+  readonly cards: Signal<UiCalendarCard[]> = computed(() => {
+    const visitedDays = this.cardStorageService.visitedDays();
+    return processDays(visitedDays, this.dayOfCardToReveal)
   });
 
-  private readonly cardIndexToReveal = this.overrideCardIndexToReveal ?? this.getLastContentIndex();
-
-  readonly cards: UiCalendarCard[] = calendarData.data.map((card) => {
-    const hasContents = card.contents.length > 0;
-    return {
-      ...card,
-      revealed: hasContents && card.day <= this.cardIndexToReveal,
-      canReveal: hasContents,
-    };
-  });
-
-  private getLastContentIndex(): number {
-    let lastIndex = 0;
-    calendarData.data.forEach((card, index) => {
+  private getLastContentDay(): number {
+    let lastDay = 1;
+    calendarData.data.forEach((card) => {
       if (card.contents.length > 0) {
-        lastIndex = index;
+        lastDay = card.day;
       }
     });
-    return lastIndex;
+    return lastDay;
   }
 }

--- a/src/app/feature/calendar/services/card-storage.service.ts
+++ b/src/app/feature/calendar/services/card-storage.service.ts
@@ -1,0 +1,35 @@
+import {Injectable, computed, signal} from '@angular/core';
+
+@Injectable({providedIn: 'root'})
+export class CardStorageService {
+  private _visitedDays = signal<string>('');
+
+  visitedDays = computed(() => {
+    const storedDays = this._visitedDays();
+
+    if (storedDays) {
+      return storedDays.split(',').map(Number);
+    }
+
+    return [];
+  });
+
+  init() {
+    const visitedDays = localStorage.getItem('visitedDays');
+    if (visitedDays) {
+      this._visitedDays.set(visitedDays);
+    }
+  }
+
+  storeAsVisited(day: number) {
+    this._visitedDays.update((prevDays) => {
+      if (prevDays) {
+        return `${prevDays},${day}`;
+      }
+
+      return `${day}`;
+    });
+
+    localStorage.setItem('visitedDays', this._visitedDays());
+  }
+}


### PR DESCRIPTION
Store users visited days in local storage, so only those visited will be opened when the page is loaded again.

Since visitors have already opened some cards but have not been stored in local storage, they will see all the cards closed initially with only the one of the current day bouncing to be opened. When they start interacting with the cards, they will be tracked and when the page is reloaded, the visited cards will be in an open state by default.